### PR TITLE
Clean up V2 and AhDoozy references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     testImplementation "net.runelite:jshell:${runeLiteVersion}"
 }
 
-group = 'com.ahdoozy.goaltrackerv2'
+group = 'com.toofifty.goaltracker'
 version = '1.0.4'
 
 tasks.withType(JavaCompile) {

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# AhDoozy's Changelog
+# Changelog
 
 ### Added
 - Item task auto-detection across inventory, equipment, bank, seed vault, and group storage.

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,5 +1,5 @@
 displayName=Goal Tracker
-author=AhDoozy
+author=toofifty
 support=https://github.com/toofifty/goaltracker
 description=Track and organize RuneScape goals with progress bars, presets, and more.
 tags=task,to-do,todo,Track,organize,progress

--- a/src/main/java/com/toofifty/goaltracker/GoalTrackerPlugin.java
+++ b/src/main/java/com/toofifty/goaltracker/GoalTrackerPlugin.java
@@ -41,7 +41,7 @@ import java.awt.*;
 import java.util.List;
 
 @Slf4j
-@PluginDescriptor(name = "Goal Tracker V2", description = "Keep track of your goals and complete them automatically")
+@PluginDescriptor(name = "Goal Tracker", description = "Keep track of your goals and complete them automatically")
 /**
  * Main entry point for the Goal Tracker plugin.
  * Handles lifecycle (startup/shutdown), UI registration, and listens for
@@ -195,7 +195,7 @@ public final class GoalTrackerPlugin extends Plugin
         // Defensive guards to avoid NPEs during test bootstrap if DI bindings are missing
         if (goalManager == null || itemCache == null || goalTrackerPanel == null || itemManager == null || clientToolbar == null)
         {
-            log.warn("GoalTrackerV2Plugin: skipping full startup because a dependency was null. goalManager={}, itemCache={}, panel={}, itemManager={}, toolbar={}",
+            log.warn("GoalTrackerPlugin: skipping full startup because a dependency was null. goalManager={}, itemCache={}, panel={}, itemManager={}, toolbar={}",
                     goalManager != null, itemCache != null, goalTrackerPanel != null, itemManager != null, clientToolbar != null);
             return;
         }
@@ -204,7 +204,7 @@ public final class GoalTrackerPlugin extends Plugin
             goalManager.load();
             itemCache.load();
         } catch (Exception ex) {
-            log.error("GoalTrackerV2Plugin: failed to load persisted state", ex);
+            log.error("GoalTrackerPlugin: failed to load persisted state", ex);
         }
 
         goalTrackerPanel.home();
@@ -212,7 +212,7 @@ public final class GoalTrackerPlugin extends Plugin
         final AsyncBufferedImage icon = itemManager.getImage(ItemID.TODO_LIST);
         if (icon == null)
         {
-            log.warn("GoalTrackerV2Plugin: icon was null; skipping sidebar button creation");
+            log.warn("GoalTrackerPlugin: icon was null; skipping sidebar button creation");
         }
         else
         {


### PR DESCRIPTION
## Summary
- Remove "V2" from plugin descriptor and logging
- Update Gradle group ID to `com.toofifty.goaltracker`
- Replace plugin metadata author and clean changelog heading

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68acaee24890832db9ca385bc130c47c